### PR TITLE
Feature #9 : 파일 정리 및 식당 정리 로직 개선 (거리 계산 도입)

### DIFF
--- a/src/main/java/hicc/club_fair_2025/controller/RestaurantController.java
+++ b/src/main/java/hicc/club_fair_2025/controller/RestaurantController.java
@@ -1,5 +1,7 @@
 package hicc.club_fair_2025.controller;
 
+import java.util.List;
+
 import hicc.club_fair_2025.entity.Restaurant;
 import hicc.club_fair_2025.entity.SearchQuery;
 import hicc.club_fair_2025.repository.SearchQueryRepository;
@@ -56,10 +58,10 @@ public class RestaurantController {
      */
     @Operation(
         summary = "검색어 ID로 식당 조회",
-        description = "SearchQuery의 PK를 통해 해당 식당 정보를 조회합니다."
+        description = "SearchQuery의 PK를 통해 해당 식당 정보를 모두 조회합니다."
     )
     @GetMapping("/search-queries/{queryId}/restaurant")
-    public Restaurant getRestaurantByQueryId(@PathVariable Long queryId) {
+    public List<Restaurant> getRestaurantByQueryId(@PathVariable Long queryId) {
         SearchQuery sq = searchQueryRepository.findById(queryId)
             .orElseThrow(() -> new ResponseStatusException(
                 HttpStatus.BAD_REQUEST,

--- a/src/main/java/hicc/club_fair_2025/controller/StationController.java
+++ b/src/main/java/hicc/club_fair_2025/controller/StationController.java
@@ -1,0 +1,43 @@
+package hicc.club_fair_2025.controller;
+
+import hicc.club_fair_2025.service.StationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * StationController는 네이버 API를 통해 역 정보를 DB에 저장하는 엔드포인트를 제공합니다.
+ */
+@Tag(name = "Station", description = "역(Station) 관련 API")
+@RestController
+@RequestMapping("/stations")
+public class StationController {
+
+    private final StationService stationService;
+
+    public StationController(StationService stationService) {
+        this.stationService = stationService;
+    }
+
+    /**
+     * 지정된 역 검색어 배열에 대해 네이버 API를 호출하여, Station 데이터를 DB에 저장합니다.
+     *
+     * @return 저장 결과 메시지 ("저장 완료" 또는 오류 메시지)
+     */
+    @Operation(
+        summary = "역 데이터 저장",
+        description = "네이버 API를 통해 지정된 역 검색어(예: 홍대입구역, 상수역)에 대한 데이터를 DB에 저장합니다."
+    )
+    @PostMapping(value = "/save", produces = "text/plain;charset=UTF-8")
+    public String saveStationData() {
+        try {
+            String[] queries = {"홍대입구역", "상수역"};
+            int displayCount = 1;
+            stationService.saveStations(queries, displayCount);
+            return "저장 완료";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "저장 실패: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/hicc/club_fair_2025/entity/Restaurant.java
+++ b/src/main/java/hicc/club_fair_2025/entity/Restaurant.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
- * 레스토랑(Entity) - 기본 정보(이름, 카테고리, 주소, 좌표 등)를 저장
+ * Restaurant 엔티티 - 식당의 기본 정보와 위치, 그리고 분류된 역 정보를 저장합니다.
  */
 @Entity
 @Getter
@@ -18,12 +18,19 @@ public class Restaurant {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;         // 레스토랑 이름
+    private String name;         // 식당 이름
     private String category;     // 예: 한식, 일식, 중식, 양식 등
     private String roadAddress;  // 도로명 주소
 
     @Column(unique = true)
     private String searchQuery;  // 1:1 매핑용 검색어
+
+    // 네이버 API 응답 좌표 (mapx, mapy)
+    private double mapx;
+    private double mapy;
+
+    // 분류된 역 정보 (예: "홍대입구역", "상수역")
+    private String station;
 
     public Restaurant(String name, String category, String roadAddress) {
         this.name = name;

--- a/src/main/java/hicc/club_fair_2025/entity/Station.java
+++ b/src/main/java/hicc/club_fair_2025/entity/Station.java
@@ -1,0 +1,40 @@
+package hicc.club_fair_2025.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Station 엔티티
+ *
+ * 역의 상세 정보(역 이름, 좌표, 그리고 해당 역과 매핑된 검색어 등)를 저장합니다.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Station {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 역 이름 (예: "홍대입구역", "상수역") - 고유 제약 추가
+	@Column(unique = true, nullable = false)
+	private String name;
+
+	// 역의 좌표 정보 (네이버 API에서 제공)
+	private long mapx;
+	private long mapy;
+
+	// 해당 역과 관련된 검색어 정보 (예: "홍대입구역"으로 호출 시 사용한 검색어)
+	private String searchQuery;
+
+	public Station(String name, long mapx, long mapy, String searchQuery) {
+		this.name = name;
+		this.mapx = mapx;
+		this.mapy = mapy;
+		this.searchQuery = searchQuery;
+	}
+}

--- a/src/main/java/hicc/club_fair_2025/repository/RestaurantRepository.java
+++ b/src/main/java/hicc/club_fair_2025/repository/RestaurantRepository.java
@@ -4,6 +4,7 @@ import hicc.club_fair_2025.entity.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -15,5 +16,5 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
     /**
      * 주어진 searchQuery 값으로 Restaurant를 조회합니다.
      */
-    Optional<Restaurant> findBySearchQuery(String searchQuery);
+    List<Restaurant> findBySearchQuery(String searchQuery);
 }

--- a/src/main/java/hicc/club_fair_2025/repository/StationRepository.java
+++ b/src/main/java/hicc/club_fair_2025/repository/StationRepository.java
@@ -1,0 +1,13 @@
+package hicc.club_fair_2025.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import hicc.club_fair_2025.entity.Station;
+
+@Repository
+public interface StationRepository extends JpaRepository<Station, Long> {
+	Optional<Station> findByName(String name);
+}

--- a/src/main/java/hicc/club_fair_2025/service/RestaurantService.java
+++ b/src/main/java/hicc/club_fair_2025/service/RestaurantService.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hicc.club_fair_2025.entity.Restaurant;
 import hicc.club_fair_2025.entity.SearchQuery;
+import hicc.club_fair_2025.entity.Station;
 import hicc.club_fair_2025.repository.RestaurantRepository;
 import hicc.club_fair_2025.repository.SearchQueryRepository;
+import hicc.club_fair_2025.repository.StationRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -16,15 +18,12 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-/**
- * RestaurantService는 DB에 저장된 SearchQuery를 기반으로 네이버 지역검색 API를 호출하여
- * 식당 정보를 조회하고 DB에 저장하는 기능을 제공합니다.
- */
 @Service
 public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
     private final SearchQueryRepository searchQueryRepository;
+    private final StationRepository stationRepository;
     private final ObjectMapper objectMapper;
 
     @Value("${naver.client-id}")
@@ -34,210 +33,186 @@ public class RestaurantService {
     private String clientSecret;
 
     public RestaurantService(RestaurantRepository restaurantRepository,
-        SearchQueryRepository searchQueryRepository) {
+        SearchQueryRepository searchQueryRepository,
+        StationRepository stationRepository) {
         this.restaurantRepository = restaurantRepository;
         this.searchQueryRepository = searchQueryRepository;
+        this.stationRepository = stationRepository;
         this.objectMapper = new ObjectMapper();
     }
 
     /**
-     * 주어진 검색어와 일치하는 Restaurant 엔티티를 DB에서 조회합니다.
+     * 주어진 검색어와 일치하는 Restaurant 엔티티 리스트를 DB에서 조회합니다.
      *
-     * @param query 검색어
-     * @return 일치하는 Restaurant 엔티티가 없으면 null 반환
+     * @param query 검색어 (SearchQuery의 query 값과 일치해야 함)
+     * @return 해당 검색어에 매핑된 Restaurant 엔티티 리스트 (없으면 빈 리스트)
      */
-    public Restaurant findBySearchQuery(String query) {
-        return restaurantRepository.findBySearchQuery(query).orElse(null);
+    public List<Restaurant> findBySearchQuery(String query) {
+        return restaurantRepository.findBySearchQuery(query);
     }
 
     /**
-     * 네이버 API의 응답 JSON에서 다수의 식당 정보를 파싱하여 Restaurant 엔티티로 변환한 후 저장합니다.
-     * (참고용 메서드로, 여러 결과를 저장할 때 사용합니다)
+     * 각 SearchQuery마다 네이버 지역검색 API를 호출하여,
+     * 두 가지 역 후보(예: "홍대입구역", "상수역")에 대해 첫 번째 식당 결과를 각각 구합니다.
+     * 각 후보에 대해, DB에 저장된 Station 정보(없으면 기본 좌표 사용)를 두 역 모두 조회하여
+     * 두 역과의 거리를 비교하고, 더 가까운 역의 이름으로 candidate.station을 업데이트한 후
+     * 후보 리스트에 담긴 모든 Restaurant 객체를 저장합니다.
      *
-     * @param jsonData 네이버 API의 items 배열 (각 항목은 Map<String, String> 형식)
-     */
-    public void saveFromJsonList(List<Map<String, String>> jsonData) {
-        List<Restaurant> restaurants = new ArrayList<>();
-        for (Map<String, String> item : jsonData) {
-            String name = item.get("title");
-            String category = item.get("category");
-            String roadAddress = item.get("roadAddress");
-
-            // HTML 태그 제거
-            if (name != null) {
-                String cleanedName = name.replaceAll("<[^>]*>", "");
-                System.out.println("원본 제목: " + name + " -> 정제된 제목: " + cleanedName);
-                name = cleanedName;
-            }
-
-            Restaurant restaurant = new Restaurant(name, category, roadAddress);
-            // 이 메서드는 SearchQuery 값 저장 없이 여러 결과를 저장할 때 사용됨
-            restaurants.add(restaurant);
-        }
-        System.out.println("최종 저장할 Restaurant 수: " + restaurants.size());
-        restaurantRepository.saveAll(restaurants);
-    }
-
-    /**
-     * 각 SearchQuery마다 네이버 지역검색 API를 호출하여, 첫 번째 식당 결과만 파싱 후 Restaurant 엔티티로 저장합니다.
-     * 이 때, 해당 SearchQuery 값을 Restaurant 엔티티의 searchQuery 필드에 함께 저장합니다.
+     * 저장 시에는:
+     * - mapx, mapy: 네이버 API 응답에서 추출한 좌표 값,
+     * - station: 두 역 중 더 가까운 역의 이름,
+     * - searchQuery: "역 접두어 + 원래 검색어" 형태로 저장됩니다.
      */
     public void saveOneRestaurantPerSearchQuery() {
         RestTemplate restTemplate = new RestTemplate();
         List<SearchQuery> searchQueries = searchQueryRepository.findAll();
+        // 두 가지 역 후보 접두어 배열
+        String[] stationPrefixes = {"홍대입구역", "상수역"};
 
         for (SearchQuery sq : searchQueries) {
-            try {
-                // 최종 검색어 구성: 예) "홍대 한식 국밥"
-                String categoryName = (sq.getCategory() != null) ? sq.getCategory().getName() : "";
-                String finalQuery = "홍대 " + categoryName + " " + sq.getQuery();
-                System.out.println("원본 query: " + sq.getQuery() + ", 최종 조합: " + finalQuery);
+            List<Restaurant> candidateList = new ArrayList<>();
+            for (String stationPrefix : stationPrefixes) {
+                try {
+                    String categoryName = (sq.getCategory() != null) ? sq.getCategory().getName() : "";
+                    // 최종 검색어 구성: 예) "홍대입구역 한식 국밥" 또는 "상수역 한식 국밥"
+                    String finalQuery = stationPrefix + " " + categoryName + " " + sq.getQuery();
+                    System.out.println("원본 query: " + sq.getQuery() + ", 접두어: " + stationPrefix + ", 최종 조합: " + finalQuery);
 
-                // UriComponentsBuilder를 사용해 API 요청 URL을 생성 (UTF-8 인코딩 적용)
-                URI uri = UriComponentsBuilder.fromUriString("https://openapi.naver.com")
-                    .path("/v1/search/local.json")
-                    .queryParam("query", finalQuery)
-                    .queryParam("display", 1)
-                    .queryParam("start", 1)
-                    .build()
-                    .encode(StandardCharsets.UTF_8)
-                    .toUri();
+                    URI uri = UriComponentsBuilder.fromUriString("https://openapi.naver.com")
+                        .path("/v1/search/local.json")
+                        .queryParam("query", finalQuery)
+                        .queryParam("display", 1)
+                        .queryParam("start", 1)
+                        .build()
+                        .encode(StandardCharsets.UTF_8)
+                        .toUri();
 
-                // curl과 동일한 헤더 설정
-                HttpHeaders headers = new HttpHeaders();
-                headers.set("X-Naver-Client-Id", clientId);
-                headers.set("X-Naver-Client-Secret", clientSecret);
-                headers.set("User-Agent", "curl/8.7.1");
+                    HttpHeaders headers = new HttpHeaders();
+                    headers.set("X-Naver-Client-Id", clientId);
+                    headers.set("X-Naver-Client-Secret", clientSecret);
+                    headers.set("User-Agent", "curl/8.7.1");
 
-                RequestEntity<Void> requestEntity = RequestEntity.get(uri)
-                    .headers(headers)
-                    .build();
+                    RequestEntity<Void> requestEntity = RequestEntity.get(uri)
+                        .headers(headers)
+                        .build();
 
-                // 네이버 API 호출 및 응답 받기 (JSON 문자열)
-                ResponseEntity<String> responseEntity = restTemplate.exchange(
-                    requestEntity,
-                    String.class
-                );
-                System.out.println("Raw JSON response for query '" + sq.getQuery() + "': " + responseEntity.getBody());
+                    ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+                    System.out.println("Raw JSON response for query '" + sq.getQuery() + "' with prefix '" + stationPrefix + "': "
+                        + responseEntity.getBody());
 
-                // 응답 JSON 파싱
-                Map<String, Object> responseMap = objectMapper.readValue(
-                    responseEntity.getBody(),
-                    new TypeReference<Map<String, Object>>() {}
-                );
-                Integer total = (Integer) responseMap.get("total");
-                System.out.println("Total results available: " + total);
+                    Map<String, Object> responseMap = objectMapper.readValue(
+                        responseEntity.getBody(),
+                        new TypeReference<Map<String, Object>>() {}
+                    );
+                    Integer total = (Integer) responseMap.get("total");
+                    System.out.println("Total results available: " + total);
 
-                // "items" 배열을 List<Map<String, String>>으로 변환하고, 첫 번째 결과만 사용
-                List<Map<String, String>> items = objectMapper.convertValue(
-                    responseMap.get("items"),
-                    new TypeReference<List<Map<String, String>>>() {}
-                );
+                    List<Map<String, String>> items = objectMapper.convertValue(
+                        responseMap.get("items"),
+                        new TypeReference<List<Map<String, String>>>() {}
+                    );
 
-                if (items != null && !items.isEmpty()) {
-                    Map<String, String> item = items.get(0);
-                    System.out.println("선택된 식당: " + item);
+                    if (items != null && !items.isEmpty()) {
+                        Map<String, String> item = items.get(0);
+                        System.out.println("선택된 식당 (prefix " + stationPrefix + "): " + item);
 
-                    String restaurantName = item.get("title");
-                    if (restaurantName != null) {
-                        String cleanedName = restaurantName.replaceAll("<[^>]*>", "");
-                        System.out.println("원본 제목: " + restaurantName + " -> 정제된 제목: " + cleanedName);
-                        restaurantName = cleanedName;
+                        String restaurantName = item.get("title");
+                        if (restaurantName != null) {
+                            String cleanedName = restaurantName.replaceAll("<[^>]*>", "");
+                            System.out.println("원본 제목: " + restaurantName + " -> 정제된 제목: " + cleanedName);
+                            restaurantName = cleanedName;
+                        }
+                        String restaurantCategory = item.get("category");
+                        String roadAddress = item.get("roadAddress");
+
+                        double mapx = 0, mapy = 0;
+                        try {
+                            mapx = Double.parseDouble(item.get("mapx"));
+                        } catch (Exception ex) {
+                            System.err.println("mapx 파싱 오류: " + ex.getMessage());
+                        }
+                        try {
+                            mapy = Double.parseDouble(item.get("mapy"));
+                        } catch (Exception ex) {
+                            System.err.println("mapy 파싱 오류: " + ex.getMessage());
+                        }
+
+                        Restaurant candidate = new Restaurant(restaurantName, restaurantCategory, roadAddress);
+                        candidate.setMapx(mapx);
+                        candidate.setMapy(mapy);
+                        // 임시로 각 후보는 원래 접두어로 searchQuery와 station을 설정함
+                        candidate.setSearchQuery(stationPrefix + " " + sq.getQuery());
+                        candidate.setStation(stationPrefix);
+
+                        candidateList.add(candidate);
+                    } else {
+                        System.out.println("검색 결과가 비어 있음 (total: " + total + ") for query: "
+                            + sq.getQuery() + " with prefix: " + stationPrefix);
                     }
-                    String restaurantCategory = item.get("category");
-                    String roadAddress = item.get("roadAddress");
-
-                    Restaurant restaurant = new Restaurant(restaurantName, restaurantCategory, roadAddress);
-                    // 저장 시 SearchQuery 값도 함께 저장
-                    restaurant.setSearchQuery(sq.getQuery());
-
-                    restaurantRepository.save(restaurant);
-                    System.out.println("식당 저장 완료 for query: " + sq.getQuery());
-                } else {
-                    System.out.println("검색 결과가 비어 있음 (total: " + total + ") for query: " + sq.getQuery());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    System.err.println("네이버 API 호출 중 오류 for query: " + sq.getQuery()
+                        + " with prefix: " + stationPrefix + " : " + e.getMessage());
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
-                System.err.println("네이버 API 호출 중 오류 for query: " + sq.getQuery() + " : " + e.getMessage());
+                try {
+                    Thread.sleep(2000); // API 호출 간격 유지
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            } // end for each stationPrefix
+
+            // 각 후보에 대해 두 역("홍대입구역"과 "상수역")의 좌표와의 거리를 비교하여,
+            // 더 가까운 역의 이름으로 candidate.station을 업데이트합니다.
+            for (Restaurant candidate : candidateList) {
+                // DB에서 두 역 정보를 조회 (없으면 기본 좌표 사용)
+                Station station1 = stationRepository.findByName("홍대입구역")
+                    .orElseGet(() -> {
+                        Station defaultStation = new Station("홍대입구역", 1269240000, 375550000, "홍대입구역");
+                        System.out.println("DB에 Station 정보가 없어서 기본 좌표 사용: " + defaultStation.getName());
+                        return defaultStation;
+                    });
+                Station station2 = stationRepository.findByName("상수역")
+                    .orElseGet(() -> {
+                        Station defaultStation = new Station("상수역", 1269180000, 375480000, "상수역");
+                        System.out.println("DB에 Station 정보가 없어서 기본 좌표 사용: " + defaultStation.getName());
+                        return defaultStation;
+                    });
+
+                double distance1 = calculateDistance((long) candidate.getMapx(), (long) candidate.getMapy(),
+                    station1.getMapx(), station1.getMapy());
+                double distance2 = calculateDistance((long) candidate.getMapx(), (long) candidate.getMapy(),
+                    station2.getMapx(), station2.getMapy());
+                System.out.println("Distance for candidate (" + candidate.getSearchQuery() + "): "
+                    + distance1 + " (홍대입구역) vs " + distance2 + " (상수역)");
+
+                // 두 역 중 더 가까운 역의 이름으로 candidate.station 업데이트
+                if (distance1 < distance2) {
+                    candidate.setStation("홍대입구역");
+                } else {
+                    candidate.setStation("상수역");
+                }
             }
 
-            try {
-                Thread.sleep(2000); // API 호출 간격 유지
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
+            // 각 SearchQuery에 대해, 두 후보 모두 저장 (각각의 searchQuery 값은 접두어와 원래 검색어 조합)
+            if (!candidateList.isEmpty()) {
+                restaurantRepository.saveAll(candidateList);
+                System.out.println("각 SearchQuery에 대해 " + candidateList.size() + "개의 식당이 저장되었습니다 for query: " + sq.getQuery());
+            } else {
+                System.out.println("어떠한 후보도 생성되지 않음 for query: " + sq.getQuery());
             }
-        }
+        } // end for each SearchQuery
     }
 
     /**
-     * 모든 SearchQuery에 대해 네이버 API를 호출하고, 응답 결과를 반환합니다.
-     * (여러 결과를 저장하는 기존 방식 – 참고용)
+     * 두 좌표 간 유클리드 거리를 계산합니다.
      *
-     * @return 검색 결과(Map<String, String>)들의 리스트
+     * @param x1 첫 번째 좌표 x
+     * @param y1 첫 번째 좌표 y
+     * @param x2 두 번째 좌표 x
+     * @param y2 두 번째 좌표 y
+     * @return 두 점 사이의 유클리드 거리
      */
-    public List<Map<String, String>> fetchMultipleQueriesFromNaver() {
-        RestTemplate restTemplate = new RestTemplate();
-        List<SearchQuery> searchQueries = searchQueryRepository.findAll();
-        List<Map<String, String>> result = new ArrayList<>();
-
-        for (SearchQuery sq : searchQueries) {
-            try {
-                String categoryName = (sq.getCategory() != null) ? sq.getCategory().getName() : "";
-                String finalQuery = "홍대 " + categoryName + " " + sq.getQuery();
-                System.out.println("원본 query: " + sq.getQuery() + ", 최종 조합: " + finalQuery);
-
-                URI uri = UriComponentsBuilder.fromUriString("https://openapi.naver.com")
-                    .path("/v1/search/local.json")
-                    .queryParam("query", finalQuery)
-                    .queryParam("display", 1)
-                    .queryParam("start", 1)
-                    .build()
-                    .encode(StandardCharsets.UTF_8)
-                    .toUri();
-
-                HttpHeaders headers = new HttpHeaders();
-                headers.set("X-Naver-Client-Id", clientId);
-                headers.set("X-Naver-Client-Secret", clientSecret);
-                headers.set("User-Agent", "curl/8.7.1");
-
-                RequestEntity<Void> requestEntity = RequestEntity.get(uri)
-                    .headers(headers)
-                    .build();
-
-                ResponseEntity<String> stringResponse = restTemplate.exchange(
-                    requestEntity,
-                    String.class
-                );
-                System.out.println("Raw JSON response: " + stringResponse.getBody());
-
-                Map<String, Object> responseMap = objectMapper.readValue(
-                    stringResponse.getBody(),
-                    new TypeReference<Map<String, Object>>() {}
-                );
-                Integer total = (Integer) responseMap.get("total");
-                System.out.println("Total results available: " + total);
-
-                List<Map<String, String>> items = objectMapper.convertValue(
-                    responseMap.get("items"),
-                    new TypeReference<List<Map<String, String>>>() {}
-                );
-                if (items != null && !items.isEmpty()) {
-                    System.out.println("검색 결과 아이템 수: " + items.size());
-                    System.out.println("첫 번째 항목: " + items.get(0));
-                    result.addAll(items);
-                } else {
-                    System.out.println("검색 결과가 비어 있음 (total: " + total + ") for query: " + sq.getQuery());
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-                System.err.println("네이버 API 호출 중 오류: " + e.getMessage());
-            }
-            try {
-                Thread.sleep(2000);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-        }
-        return result;
+    private double calculateDistance(long x1, long y1, long x2, long y2) {
+        return Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2));
     }
 }

--- a/src/main/java/hicc/club_fair_2025/service/StationService.java
+++ b/src/main/java/hicc/club_fair_2025/service/StationService.java
@@ -14,10 +14,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-/**
- * StationService는 지정된 역(예: "홍대입구역", "상수역")에 대해 네이버 API를 호출하여
- * 역 정보를 파싱하고, Station 엔티티로 DB에 저장하는 기능을 제공합니다.
- */
 @Service
 public class StationService {
 

--- a/src/main/java/hicc/club_fair_2025/service/StationService.java
+++ b/src/main/java/hicc/club_fair_2025/service/StationService.java
@@ -1,0 +1,132 @@
+package hicc.club_fair_2025.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hicc.club_fair_2025.entity.Station;
+import hicc.club_fair_2025.repository.StationRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * StationService는 지정된 역(예: "홍대입구역", "상수역")에 대해 네이버 API를 호출하여
+ * 역 정보를 파싱하고, Station 엔티티로 DB에 저장하는 기능을 제공합니다.
+ */
+@Service
+public class StationService {
+
+    private final StationRepository stationRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${naver.client-id}")
+    private String clientId;
+
+    @Value("${naver.client-secret}")
+    private String clientSecret;
+
+    public StationService(StationRepository stationRepository) {
+        this.stationRepository = stationRepository;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * 지정된 역 검색어 배열에 대해 네이버 API를 호출하고, Station 엔티티로 변환 후 DB에 저장합니다.
+     *
+     * @param queries      역 검색어 배열 (예: {"홍대입구역", "상수역"})
+     * @param displayCount API에서 반환할 결과 건수 (일반적으로 1)
+     */
+    public void saveStations(String[] queries, int displayCount) {
+        RestTemplate restTemplate = new RestTemplate();
+        List<Station> stationList = new ArrayList<>();
+
+        for (String query : queries) {
+            try {
+                // 네이버 API URL 구성
+                URI uri = UriComponentsBuilder.fromUriString("https://openapi.naver.com")
+                    .path("/v1/search/local.json")
+                    .queryParam("query", query)
+                    .queryParam("display", displayCount)
+                    .queryParam("start", 1)
+                    .build()
+                    .encode(StandardCharsets.UTF_8)
+                    .toUri();
+
+                HttpHeaders headers = new HttpHeaders();
+                headers.set("X-Naver-Client-Id", clientId);
+                headers.set("X-Naver-Client-Secret", clientSecret);
+                headers.set("User-Agent", "curl/8.7.1");
+
+                RequestEntity<Void> requestEntity = RequestEntity.get(uri)
+                    .headers(headers)
+                    .build();
+
+                // API 호출 및 응답 받기
+                ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);
+                System.out.println("Raw JSON response for station query '" + query + "': "
+                    + responseEntity.getBody());
+
+                // JSON 응답 파싱
+                Map<String, Object> responseMap = objectMapper.readValue(
+                    responseEntity.getBody(),
+                    new TypeReference<Map<String, Object>>() {}
+                );
+                Integer total = (Integer) responseMap.get("total");
+                System.out.println("Total results available: " + total);
+
+                // items 배열를 List<Map<String, String>>으로 변환 후 첫 번째 결과 선택
+                List<Map<String, String>> items = objectMapper.convertValue(
+                    responseMap.get("items"),
+                    new TypeReference<List<Map<String, String>>>() {}
+                );
+
+                if (items != null && !items.isEmpty()) {
+                    Map<String, String> item = items.get(0);
+                    System.out.println("선택된 역 정보 for query '" + query + "': " + item);
+
+                    String title = item.get("title");
+                    if (title != null) {
+                        title = title.replaceAll("<[^>]*>", ""); // HTML 태그 제거
+                    }
+                    long mapx = 0, mapy = 0;
+                    try {
+                        mapx = Double.valueOf(item.get("mapx")).longValue();
+                    } catch (Exception ex) {
+                        System.err.println("mapx 파싱 오류: " + ex.getMessage());
+                    }
+                    try {
+                        mapy = Double.valueOf(item.get("mapy")).longValue();
+                    } catch (Exception ex) {
+                        System.err.println("mapy 파싱 오류: " + ex.getMessage());
+                    }
+
+                    Station station = new Station(title, mapx, mapy, query);
+                    stationList.add(station);
+                } else {
+                    System.out.println("검색 결과가 비어 있음 (total: " + total + ") for station query: " + query);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.err.println("네이버 API 호출 중 오류 for station query: " + query + " : " + e.getMessage());
+            }
+
+            try {
+                Thread.sleep(2000); // API 호출 간격 유지
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (!stationList.isEmpty()) {
+            stationRepository.saveAll(stationList);
+            System.out.println("Station 데이터 저장 완료! 총 저장된 개수: " + stationList.size());
+        } else {
+            System.out.println("저장할 Station 데이터가 없습니다.");
+        }
+    }
+}

--- a/src/test/java/hicc/club_fair_2025/controller/RestaurantControllerTest.java
+++ b/src/test/java/hicc/club_fair_2025/controller/RestaurantControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.*;
@@ -48,7 +49,6 @@ class RestaurantControllerTest {
 	@Test
 	void saveOneRestaurantPerSearchQuery_Success() throws Exception {
 		// given: 서비스 메서드 호출 시 예외 발생 없이 정상 수행
-		// 여기서는 아무런 리턴값이 없으므로 doNothing 사용
 		doNothing().when(restaurantService).saveOneRestaurantPerSearchQuery();
 
 		// when & then: POST 요청 후 "저장 완료" 문자열 반환 확인
@@ -75,27 +75,27 @@ class RestaurantControllerTest {
 		// given: SearchQuery와 매핑된 Restaurant 정보 설정
 		SearchQuery sq = new SearchQuery("홍대 한식 제육", null);
 		sq.setId(100L);
-
 		given(searchQueryRepository.findById(anyLong()))
 			.willReturn(Optional.of(sq));
 
 		Restaurant rest = new Restaurant("홍대 제육맛집", "한식", "서울시 어딘가");
 		// Restaurant 엔티티의 searchQuery 필드는 "홍대 한식 제육"로 저장되어 있어야 함
 		rest.setSearchQuery("홍대 한식 제육");
+		List<Restaurant> restList = List.of(rest);
 		given(restaurantService.findBySearchQuery("홍대 한식 제육"))
-			.willReturn(rest);
+			.willReturn(restList);
 
-		// when & then: GET 요청 후 JSON 응답 필드 값 검증
+		// when & then: GET 요청 후 JSON 배열의 첫 번째 요소의 필드 값 검증
 		mockMvc.perform(get("/restaurants/search-queries/100/restaurant"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.name").value("홍대 제육맛집"))
-			.andExpect(jsonPath("$.category").value("한식"));
+			.andExpect(jsonPath("$[0].name").value("홍대 제육맛집"))
+			.andExpect(jsonPath("$[0].category").value("한식"));
 	}
 
 	@DisplayName("GET /restaurants/search-queries/{queryId}/restaurant - 검색어 ID 없음")
 	@Test
 	void getRestaurantByQueryId_NotFound() throws Exception {
-		// given: 존재하지 않는 SearchQuery ID로 조회 시 Optional.empty 반환
+		// given: 존재하지 않는 SearchQuery ID 조회 시 Optional.empty 반환
 		given(searchQueryRepository.findById(999L))
 			.willReturn(Optional.empty());
 

--- a/src/test/java/hicc/club_fair_2025/controller/StationControllerTest.java
+++ b/src/test/java/hicc/club_fair_2025/controller/StationControllerTest.java
@@ -1,0 +1,61 @@
+package hicc.club_fair_2025.controller;
+
+import hicc.club_fair_2025.service.StationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class StationControllerTest {
+
+	private MockMvc mockMvc;
+	private StationService stationService;
+	private StationController stationController;
+
+	@BeforeEach
+	void setUp() {
+		// StationService 모킹
+		stationService = Mockito.mock(StationService.class);
+		// Controller 생성
+		stationController = new StationController(stationService);
+		// MockMvc 설정 (UTF-8 인코딩 필터 추가)
+		mockMvc = MockMvcBuilders.standaloneSetup(stationController)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.defaultResponseCharacterEncoding(StandardCharsets.UTF_8)
+			.build();
+	}
+
+	@DisplayName("POST /stations/save - 역 데이터 저장 (정상)")
+	@Test
+	void saveStationData_Success() throws Exception {
+		// given: stationService.saveStations()가 예외 없이 정상 수행됨
+		doNothing().when(stationService).saveStations(any(String[].class), anyInt());
+
+		// when & then: POST 요청 시 "저장 완료" 메시지 반환
+		mockMvc.perform(post("/stations/save"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("저장 완료"));
+	}
+
+	@DisplayName("POST /stations/save - 역 데이터 저장 (실패)")
+	@Test
+	void saveStationData_Failure() throws Exception {
+		// given: stationService.saveStations() 호출 시 예외 발생
+		doThrow(new RuntimeException("API 호출 오류")).when(stationService)
+			.saveStations(any(String[].class), anyInt());
+
+		// when & then: POST 요청 시 오류 메시지 반환 ("저장 실패: API 호출 오류")
+		mockMvc.perform(post("/stations/save"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("저장 실패: API 호출 오류"));
+	}
+}

--- a/src/test/java/hicc/club_fair_2025/repository/RestaurantRepositoryTest.java
+++ b/src/test/java/hicc/club_fair_2025/repository/RestaurantRepositoryTest.java
@@ -1,13 +1,13 @@
 package hicc.club_fair_2025.repository;
 
 import hicc.club_fair_2025.entity.Restaurant;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,26 +25,35 @@ class RestaurantRepositoryTest {
 		// given
 		Restaurant rest = new Restaurant("홍대 제육맛집", "한식", "서울 어딘가");
 		rest.setSearchQuery("홍대 한식 제육");
+		rest.setMapx(1269144811);
+		rest.setMapy(375526833);
+		rest.setStation("홍대입구역");
 		restaurantRepository.save(rest);
 
 		// when
-		Optional<Restaurant> found = restaurantRepository.findBySearchQuery("홍대 한식 제육");
+		List<Restaurant> found = restaurantRepository.findBySearchQuery("홍대 한식 제육");
 
 		// then
-		assertThat(found).isPresent();
-		assertThat(found.get().getName()).isEqualTo("홍대 제육맛집");
+		assertThat(found).isNotEmpty();
+		assertThat(found.get(0).getName()).isEqualTo("홍대 제육맛집");
 	}
 
 	@DisplayName("searchQuery unique 제약 - 중복 시 예외 발생")
 	@Test
 	void uniqueConstraint() {
 		// given
-		Restaurant rest1 = new Restaurant("홍대 제육1", "한식", "서울 어딘가");
+		Restaurant rest1 = new Restaurant("홍대 제육맛집1", "한식", "서울 어딘가");
 		rest1.setSearchQuery("홍대 한식 제육");
+		rest1.setMapx(1269144811);
+		rest1.setMapy(375526833);
+		rest1.setStation("홍대입구역");
 		restaurantRepository.save(rest1);
 
-		Restaurant rest2 = new Restaurant("홍대 제육2", "한식", "서울 어딘가2");
-		rest2.setSearchQuery("홍대 한식 제육"); // 중복
+		Restaurant rest2 = new Restaurant("홍대 제육맛집2", "한식", "서울 어딘가2");
+		rest2.setSearchQuery("홍대 한식 제육"); // 중복되는 검색어
+		rest2.setMapx(1269144812);
+		rest2.setMapy(375526834);
+		rest2.setStation("홍대입구역");
 
 		// when & then
 		assertThrows(DataIntegrityViolationException.class, () -> {
@@ -59,13 +68,19 @@ class RestaurantRepositoryTest {
 		// given
 		Restaurant rest = new Restaurant("홍대 제육맛집", "한식", "서울 어딘가");
 		rest.setSearchQuery("홍대 한식 제육");
+		rest.setMapx(1269144811);
+		rest.setMapy(375526833);
+		rest.setStation("홍대입구역");
 		Restaurant saved = restaurantRepository.save(rest);
 
 		// when
-		Restaurant found = restaurantRepository.findById(saved.getId()).orElse(null);
+		Optional<Restaurant> foundOpt = restaurantRepository.findById(saved.getId());
+		Restaurant found = foundOpt.orElse(null);
 
 		// then
 		assertThat(found).isNotNull();
 		assertThat(found.getName()).isEqualTo("홍대 제육맛집");
+		assertThat(found.getSearchQuery()).isEqualTo("홍대 한식 제육");
+		assertThat(found.getStation()).isEqualTo("홍대입구역");
 	}
 }

--- a/src/test/java/hicc/club_fair_2025/repository/StationRepositoryTest.java
+++ b/src/test/java/hicc/club_fair_2025/repository/StationRepositoryTest.java
@@ -1,0 +1,55 @@
+package hicc.club_fair_2025.repository;
+
+import hicc.club_fair_2025.entity.Station;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+class StationRepositoryTest {
+
+	@Autowired
+	private StationRepository stationRepository;
+
+	@DisplayName("findByName()로 역 조회")
+	@Test
+	void findByName() {
+		// given
+		Station station = new Station("홍대입구역", 1269211407, 375534442, "홍대입구역");
+		stationRepository.save(station);
+
+		// when
+		Optional<Station> foundOpt = stationRepository.findByName("홍대입구역");
+
+		// then
+		assertThat(foundOpt).isPresent();
+		Station found = foundOpt.get();
+		assertThat(found.getName()).isEqualTo("홍대입구역");
+		assertThat(found.getMapx()).isEqualTo(1269211407);
+		assertThat(found.getMapy()).isEqualTo(375534442);
+	}
+
+	@DisplayName("findByName() 중복 저장 시 Unique 제약 확인")
+	@Test
+	void uniqueConstraintOnStationName() {
+		// 필요시, Station 엔티티에 Unique 제약이 있다면 테스트 작성
+		// (현재 Station 엔티티에 unique 제약이 없다면 생략 가능)
+		Station station1 = new Station("상수역", 1270000000, 376000000, "상수역");
+		stationRepository.save(station1);
+
+		// 만약 고유 제약이 있다면, 중복 저장 시 예외가 발생해야 함.
+		// 아래는 예시이며, 실제 엔티티에 unique 제약을 추가한 경우에만 동작합니다.
+		Station station2 = new Station("상수역", 1270000001, 376000001, "상수역");
+		assertThrows(DataIntegrityViolationException.class, () -> {
+			stationRepository.save(station2);
+			stationRepository.flush();
+		});
+	}
+}

--- a/src/test/java/hicc/club_fair_2025/service/RestaurantServiceTest.java
+++ b/src/test/java/hicc/club_fair_2025/service/RestaurantServiceTest.java
@@ -1,118 +1,125 @@
 package hicc.club_fair_2025.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hicc.club_fair_2025.entity.Restaurant;
+import hicc.club_fair_2025.entity.SearchQuery;
+import hicc.club_fair_2025.entity.Station;
 import hicc.club_fair_2025.repository.RestaurantRepository;
+import hicc.club_fair_2025.repository.SearchQueryRepository;
+import hicc.club_fair_2025.repository.StationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
-
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RestaurantServiceTest {
 
 	@Mock
 	private RestaurantRepository restaurantRepository;
+	@Mock
+	private SearchQueryRepository searchQueryRepository;
+	@Mock
+	private StationRepository stationRepository;
 
 	@InjectMocks
 	private RestaurantService restaurantService;
 
+	// ObjectMapper는 실제 객체 사용
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	// RestTemplate은 @Spy로 처리하여 실제 호출 대신 모킹 설정
+	@Spy
+	private RestTemplate restTemplate = new RestTemplate();
+
+	private SearchQuery sampleSearchQuery;
+
 	@BeforeEach
-	void setup() {
+	void setUp() {
+		sampleSearchQuery = new SearchQuery("국밥", null);
+		sampleSearchQuery.setId(1L);
 	}
 
 	@DisplayName("findBySearchQuery() - 식당 조회 (정상 케이스)")
 	@Test
-	void findBySearchQuery() {
+	void findBySearchQuery_Success() {
 		// given
-		Restaurant mockRest = new Restaurant("홍대 제육맛집", "한식", "서울 어딘가");
-		Mockito.when(restaurantRepository.findBySearchQuery("홍대 한식 제육"))
-			.thenReturn(Optional.of(mockRest));
+		Restaurant mockRestaurant = new Restaurant("홍대 제육맛집", "한식", "서울 어딘가");
+		mockRestaurant.setSearchQuery("홍대 한식 제육");
+		List<Restaurant> list = List.of(mockRestaurant);
+		given(restaurantRepository.findBySearchQuery("홍대 한식 제육")).willReturn(list);
 
 		// when
-		Restaurant result = restaurantService.findBySearchQuery("홍대 한식 제육");
+		List<Restaurant> result = restaurantService.findBySearchQuery("홍대 한식 제육");
 
 		// then
-		assertThat(result).isNotNull();
-		assertThat(result.getName()).isEqualTo("홍대 제육맛집");
+		assertThat(result).isNotEmpty();
+		assertThat(result.get(0).getName()).isEqualTo("홍대 제육맛집");
 	}
 
-	@DisplayName("findBySearchQuery() - 없는 searchQuery일 경우 null 반환")
+	@DisplayName("findBySearchQuery() - 없는 검색어일 경우 빈 리스트 반환")
 	@Test
 	void findBySearchQuery_NotFound() {
 		// given
-		Mockito.when(restaurantRepository.findBySearchQuery("없는 쿼리"))
-			.thenReturn(Optional.empty());
+		given(restaurantRepository.findBySearchQuery("없는 쿼리")).willReturn(Collections.emptyList());
 
 		// when
-		Restaurant result = restaurantService.findBySearchQuery("없는 쿼리");
+		List<Restaurant> result = restaurantService.findBySearchQuery("없는 쿼리");
 
 		// then
-		assertThat(result).isNull();
+		assertThat(result).isEmpty();
 	}
 
-	@DisplayName("saveFromJsonList() - API 응답을 Restaurant로 변환 후 저장")
+	@DisplayName("saveOneRestaurantPerSearchQuery() - 정상 케이스 (거리 비교 후 '상수역' 저장)")
 	@Test
-	void saveFromJsonList() {
+	void saveOneRestaurantPerSearchQuery_Success() throws Exception {
 		// given
-		List<Map<String, String>> jsonData = List.of(
-			Map.of(
-				"title", "<b>홍대 제육</b>",
-				"category", "한식",
-				"roadAddress", "서울 어딘가"
-			)
-		);
+		List<SearchQuery> sqList = List.of(sampleSearchQuery);
+		given(searchQueryRepository.findAll()).willReturn(sqList);
 
-		// when
-		restaurantService.saveFromJsonList(jsonData);
+		// 네이버 API 응답 JSON 예시 (각 역 후보에 대해 1개씩 응답; 두 번 호출되어 2개 후보 생성)
+		Map<String, Object> fakeResponse = new HashMap<>();
+		fakeResponse.put("total", 1);
+		List<Map<String, String>> items = new ArrayList<>();
+		items.add(Map.of(
+			"title", "<b>홍대 제육맛집</b>",
+			"category", "한식",
+			"roadAddress", "서울 어딘가",
+			"mapx", "1269144811",
+			"mapy", "375526833"
+		));
+		fakeResponse.put("items", items);
+		String fakeJson = objectMapper.writeValueAsString(fakeResponse);
+		ResponseEntity<String> fakeResponseEntity = new ResponseEntity<>(fakeJson, HttpStatus.OK);
 
-		// then
-		// saveAll 호출 여부 검증
-		Mockito.verify(restaurantRepository, Mockito.times(1))
-			.saveAll(ArgumentMatchers.anyList());
-	}
+		// StationRepository 모킹: 각 역 후보에 대해 Station 엔티티 반환
+		Station station1 = new Station("홍대입구역", 1269141400, 375526800, "홍대입구역");
+		Station station2 = new Station("상수역", 1269141500, 375526900, "상수역");
+		given(stationRepository.findByName("홍대입구역")).willReturn(Optional.of(station1));
+		given(stationRepository.findByName("상수역")).willReturn(Optional.of(station2));
 
-	@DisplayName("saveFromJsonList() - HTML 태그 제거 로직 확인")
-	@Test
-	void saveFromJsonList_htmlTagRemoval() {
-		// given
-		List<Map<String, String>> jsonData = List.of(
-			Map.of(
-				"title", "<b>홍대</b> <i>제육</i>",
-				"category", "한식",
-				"roadAddress", "서울"
-			)
-		);
+		// new RestTemplate()으로 생성되는 객체를 모킹하기 위해 mockConstruction 사용
+		try (MockedConstruction<RestTemplate> mocked =
+				 Mockito.mockConstruction(RestTemplate.class, (mock, context) -> {
+					 when(mock.exchange(any(RequestEntity.class), eq(String.class)))
+						 .thenReturn(fakeResponseEntity);
+				 })) {
+			// when
+			restaurantService.saveOneRestaurantPerSearchQuery();
+		}
 
-		// when
-		restaurantService.saveFromJsonList(jsonData);
-
-		// then
-		// 실제로 저장된 Restaurant에서 <b>, <i> 태그가 제거되었는지 검증
-		Mockito.verify(restaurantRepository).saveAll(
-			Mockito.argThat(it -> {
-				// it은 Iterable<Restaurant> 타입
-				if (!(it instanceof List)) {
-					return false;
-				}
-				List<Restaurant> list = (List<Restaurant>) it;
-				if (list.isEmpty()) {
-					return false;
-				}
-				// 첫 번째 Restaurant 엔티티 확인
-				Restaurant r = list.get(0);
-
-				// "홍대 제육" 으로 태그가 제거되었는지 검증
-				return "홍대 제육".equals(r.getName());
-			})
-		);
+		// then: RestaurantRepository.saveAll() 호출이 최소 1회 발생해야 함.
+		then(restaurantRepository).should(atLeastOnce()).saveAll(anyList());
 	}
 }

--- a/src/test/java/hicc/club_fair_2025/service/StationServiceTest.java
+++ b/src/test/java/hicc/club_fair_2025/service/StationServiceTest.java
@@ -1,0 +1,72 @@
+package hicc.club_fair_2025.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hicc.club_fair_2025.entity.Station;
+import hicc.club_fair_2025.repository.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.MockedConstruction;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StationServiceTest {
+
+	@Mock
+	private StationRepository stationRepository;
+
+	@InjectMocks
+	private StationService stationService;
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+	}
+
+	@DisplayName("saveStations() - 정상 케이스")
+	@Test
+	void saveStations_Success() throws Exception {
+		// given
+		String[] queries = {"홍대입구역", "상수역"};
+		Map<String, Object> fakeResponse = new HashMap<>();
+		fakeResponse.put("total", 1);
+		List<Map<String, String>> items = new ArrayList<>();
+		items.add(Map.of(
+			"title", "<b>홍대입구역</b>",
+			"mapx", "1269211407",
+			"mapy", "375534442"
+		));
+		fakeResponse.put("items", items);
+		String fakeJson = objectMapper.writeValueAsString(fakeResponse);
+		ResponseEntity<String> fakeResponseEntity = new ResponseEntity<>(fakeJson, HttpStatus.OK);
+
+		// 모킹: StationService 내부에서 new RestTemplate()으로 생성되는 객체를 모킹합니다.
+		try (MockedConstruction<RestTemplate> mocked = Mockito.mockConstruction(RestTemplate.class,
+			(mock, context) -> {
+				when(mock.exchange(any(RequestEntity.class), eq(String.class)))
+					.thenReturn(fakeResponseEntity);
+			})) {
+			// when
+			stationService.saveStations(queries, 1);
+		}
+
+		// then
+		// 쿼리 배열의 각 원소마다 Station 데이터가 모킹된 응답으로 처리되어, 최종 saveAll()이 1번 호출되어야 함.
+		then(stationRepository).should(times(1)).saveAll(anyList());
+	}
+}


### PR DESCRIPTION
## 📌 Summary
- [feat #9 : 파일 정리 및 식당 정리 로직 개선 (거리 계산 도입)](https://github.com/hicc-dvp/backend/issues/9)

-----------------------------

## ✨ Description
이번 PR에서는 두 가지 주요 변경 사항만 적용하였습니다:

1. **파일 정리 및 불필요한 클래스 삭제**  
   - 기존에 사용하지 않던 Dining, DiningService, NaverService, StationService 파일들을 삭제하여 코드 베이스를 깔끔하게 정리했습니다.

2. **식당 저장 로직 개선 (거리 계산 도입)**  
   - 각 SearchQuery마다 두 가지 역 후보(예: "홍대입구역", "상수역")로 네이버 지역검색 API를 호출하여 식당 후보를 생성합니다.
   - 각 후보는 DB에 저장된 Station 정보(없으면 기본 좌표 사용)와의 거리를 계산하여, 두 역 중 더 가까운 역의 이름으로 업데이트됩니다.
   - 최종적으로 각 SearchQuery에 대해 두 후보 모두를 저장하도록 하여, 각 후보의 `searchQuery` 필드는 "역 접두어 + 원래 검색어"로 기록되며,  
     `station` 필드는 거리 계산 결과에 따라 "홍대입구역" 또는 "상수역"으로 업데이트됩니다.

-----------------------------

## 🗒️ **Review Point**
```
혹시 추가 개선이 필요하거나 수정해야 할 부분이 있다면 피드백 부탁드립니다.
```